### PR TITLE
Add option to delete git branches when deleting a task (Vibe Kanban)

### DIFF
--- a/crates/services/src/services/git.rs
+++ b/crates/services/src/services/git.rs
@@ -1208,6 +1208,19 @@ impl GitService {
         Ok(())
     }
 
+    /// Delete a local branch. Use force=true to delete unmerged branches.
+    pub fn delete_local_branch(
+        &self,
+        repo_path: &Path,
+        branch_name: &str,
+        force: bool,
+    ) -> Result<(), GitServiceError> {
+        let git = GitCli::new();
+        git.delete_local_branch(repo_path, branch_name, force)
+            .map_err(|e| GitServiceError::InvalidRepository(e.to_string()))?;
+        Ok(())
+    }
+
     pub fn get_all_branches(&self, repo_path: &Path) -> Result<Vec<GitBranch>, git2::Error> {
         let repo = Repository::open(repo_path)?;
         let current_branch = self.get_current_branch(repo_path).unwrap_or_default();

--- a/crates/services/src/services/git/cli.rs
+++ b/crates/services/src/services/git/cli.rs
@@ -154,6 +154,19 @@ impl GitCli {
         Ok(())
     }
 
+    /// Delete a local branch. Use force=true to delete unmerged branches (-D).
+    pub fn delete_local_branch(
+        &self,
+        repo_path: &Path,
+        branch_name: &str,
+        force: bool,
+    ) -> Result<(), GitCliError> {
+        self.ensure_available()?;
+        let flag = if force { "-D" } else { "-d" };
+        self.git(repo_path, ["branch", flag, branch_name])?;
+        Ok(())
+    }
+
     /// Return true if there are any changes in the working tree (staged or unstaged).
     pub fn has_changes(&self, worktree_path: &Path) -> Result<bool, GitCliError> {
         let out = self.git(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -418,8 +418,17 @@ export const tasksApi = {
     return handleApiResponse<Task>(response);
   },
 
-  delete: async (taskId: string): Promise<void> => {
-    const response = await makeRequest(`/api/tasks/${taskId}`, {
+  delete: async (
+    taskId: string,
+    options?: { deleteBranch?: boolean }
+  ): Promise<void> => {
+    const params = new URLSearchParams();
+    if (options?.deleteBranch !== undefined) {
+      params.set('delete_branch', String(options.deleteBranch));
+    }
+    const queryString = params.toString();
+    const url = `/api/tasks/${taskId}${queryString ? `?${queryString}` : ''}`;
+    const response = await makeRequest(url, {
       method: 'DELETE',
     });
     return handleApiResponse<void>(response);


### PR DESCRIPTION
## Summary

This PR adds an option to delete associated git branches when deleting a task. The feature is enabled by default, giving users control over whether to clean up branches along with the task.

## Changes

### Frontend
- **DeleteTaskConfirmationDialog**: Added a checkbox (default: checked) that allows users to opt-in/out of branch deletion
- The dialog now fetches and displays the actual branch name(s) that will be deleted, providing clear visibility into what will be affected
- Updated `tasksApi.delete()` to accept an optional `deleteBranch` parameter passed as a query string

### Backend
- **GitCli**: Added `delete_local_branch()` method that runs `git branch -d` (or `-D` for force delete)
- **GitService**: Added corresponding wrapper method for the CLI operation
- **Task deletion endpoint**: 
  - Now accepts `delete_branch` query parameter (defaults to `true`)
  - Collects branch names from all task workspaces/attempts
  - Deletes branches from each associated repository during background cleanup
  - Uses force delete (`-D`) since worktrees are removed first and branches may appear unmerged

## Implementation Details

- Branch deletion happens asynchronously in the background cleanup task, after worktree removal
- Each branch is deleted from all repositories associated with the task
- Failures are logged but don't fail the overall deletion (branch may already be deleted or not exist)
- The checkbox only appears if the task has associated branches

## User Experience

When deleting a task, users now see:
- A checkbox labeled "Also delete git branch: `branch-name`" (or "branches" for multiple)
- Branch names displayed in monospace font for clarity
- The option is checked by default but can be unchecked to preserve branches

---

This PR was written using [Vibe Kanban](https://vibekanban.com)