### PR TITLE
Skip onboarding in development mode (Vibe Kanban)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,17 +66,23 @@ function AppContent() {
 
     const showNextStep = async () => {
       // 1) Disclaimer - first step
-      if (!config.disclaimer_acknowledged) {
+      // Skip disclaimer in development mode
+      const isDevelopment = import.meta.env.MODE === 'development';
+      if (!config.disclaimer_acknowledged && !isDevelopment) {
         await DisclaimerDialog.show();
         if (!cancelled) {
           await updateAndSaveConfig({ disclaimer_acknowledged: true });
         }
         DisclaimerDialog.hide();
         return;
+      } else if (!config.disclaimer_acknowledged && isDevelopment) {
+        // In development mode, automatically acknowledge disclaimer
+        await updateAndSaveConfig({ disclaimer_acknowledged: true });
       }
 
       // 2) Onboarding - configure executor and editor
-      if (!config.onboarding_acknowledged) {
+      // Skip onboarding in development mode
+      if (!config.onboarding_acknowledged && !isDevelopment) {
         const result = await OnboardingDialog.show();
         if (!cancelled) {
           await updateAndSaveConfig({
@@ -87,6 +93,21 @@ function AppContent() {
         }
         OnboardingDialog.hide();
         return;
+      } else if (!config.onboarding_acknowledged && isDevelopment) {
+        // In development mode, automatically acknowledge onboarding with default values
+        await updateAndSaveConfig({
+          onboarding_acknowledged: true,
+          executor_profile: config.executor_profile || {
+            executor: 'CLAUDE_CODE',
+            variant: null,
+          },
+          editor: config.editor || {
+            editor_type: 'VS_CODE',
+            custom_command: null,
+            remote_ssh_host: null,
+            remote_ssh_user: null,
+          },
+        });
       }
 
       // 3) Release notes - last step


### PR DESCRIPTION
# Skip onboarding in development mode

## Summary

This PR implements a mechanism to skip the onboarding process when running in development mode. This allows developers to start the application without having to go through the new user onboarding flow.

## Changes Made

- Modified frontend/src/App.tsx to detect development mode using import.meta.env.MODE === 'development'
- Added logic to automatically acknowledge onboarding with default values in development mode
- Also skips the disclaimer dialog in development mode for a complete experience
- Maintains original behavior for production mode

## Implementation Details

- When in development mode and onboarding is not acknowledged, the app automatically sets onboarding_acknowledged: true with default values instead of showing the onboarding dialog
- Default values used in development:
  - executor_profile: { executor: 'CLAUDE_CODE', variant: null }
  - editor: { editor_type: 'VS_CODE', custom_command: null, remote_ssh_host: null, remote_ssh_user: null }
  - disclaimer_acknowledged: true
  - onboarding_acknowledged: true

This ensures that developers can run the application in development mode without having to go through the new user onboarding process, while maintaining the full onboarding experience for production users.

This PR was written using [Vibe Kanban](https://vibekanban.com)