### PR TITLE
Fix preview warning showing when iframe loads successfully (Vibe Kanban)

### DIFF
--- a/frontend/src/components/panels/PreviewPanel.tsx
+++ b/frontend/src/components/panels/PreviewPanel.tsx
@@ -18,6 +18,7 @@ import { ReadyContent } from '@/components/tasks/TaskDetails/preview/ReadyConten
 
 export function PreviewPanel() {
   const [iframeError, setIframeError] = useState(false);
+  const [iframeLoaded, setIframeLoaded] = useState(false);
   const [isReady, setIsReady] = useState(false);
   const [loadingTimeFinished, setLoadingTimeFinished] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -59,10 +60,15 @@ export function PreviewPanel() {
 
   const handleRefresh = () => {
     setIframeError(false);
+    setIframeLoaded(false);
     setRefreshKey((prev) => prev + 1);
   };
   const handleIframeError = () => {
     setIframeError(true);
+  };
+  const handleIframeLoad = () => {
+    setIframeLoaded(true);
+    setShowHelp(false);
   };
 
   const { addElement } = useClickedElements();
@@ -113,6 +119,7 @@ export function PreviewPanel() {
     if (
       loadingTimeFinished &&
       !isReady &&
+      !iframeLoaded &&
       latestDevServerProcess &&
       runningDevServer
     ) {
@@ -120,7 +127,7 @@ export function PreviewPanel() {
       setShowLogs(true);
       setLoadingTimeFinished(false);
     }
-  }, [loadingTimeFinished, isReady, latestDevServerProcess, runningDevServer]);
+  }, [loadingTimeFinished, isReady, iframeLoaded, latestDevServerProcess, runningDevServer]);
 
   const isPreviewReady =
     (previewState.status === 'ready' && Boolean(previewState.url)) ||
@@ -184,6 +191,7 @@ export function PreviewPanel() {
               url={effectiveUrl}
               iframeKey={`${effectiveUrl}-${refreshKey}`}
               onIframeError={handleIframeError}
+              onIframeLoad={handleIframeLoad}
             />
           </>
         ) : (

--- a/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
+++ b/frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx
@@ -4,12 +4,14 @@ interface ReadyContentProps {
   url?: string;
   iframeKey: string;
   onIframeError: () => void;
+  onIframeLoad?: () => void;
 }
 
 export function ReadyContent({
   url,
   iframeKey,
   onIframeError,
+  onIframeLoad,
 }: ReadyContentProps) {
   const { t } = useTranslation('tasks');
 
@@ -23,6 +25,7 @@ export function ReadyContent({
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
         referrerPolicy="no-referrer"
         onError={onIframeError}
+        onLoad={onIframeLoad}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Fixed the preview panel always showing the "We're having trouble previewing your application" warning even when the preview loads successfully.

## Problem

The warning was appearing after a 5-second timeout whenever the Web Companion browser extension hadn't signaled readiness, regardless of whether the actual iframe preview had loaded and was displaying the application correctly. This created a confusing user experience where users would see an error warning alongside a working preview.

## Solution

Added iframe load tracking to the warning logic:

- **Added `iframeLoaded` state** to track when the iframe successfully loads via the `onLoad` event
- **Updated warning condition** to check both `!isReady` (Web Companion not ready) AND `!iframeLoaded` (iframe not loaded)
- **Auto-dismiss warning** when iframe loads successfully via `handleIframeLoad` callback

Now the warning only appears when there's an actual problem loading the preview, not just when the Web Companion extension hasn't connected.

## Files Changed

- `frontend/src/components/panels/PreviewPanel.tsx` - Added iframe load tracking and updated warning logic
- `frontend/src/components/tasks/TaskDetails/preview/ReadyContent.tsx` - Added `onIframeLoad` prop to iframe

---

This PR was written using [Vibe Kanban](https://vibekanban.com)