### PR TITLE
PRs are opened in the web browser automatically, find out where this happens (vibe-kanban)

### DIFF
--- a/crates/server/src/routes/task_attempts/pr.rs
+++ b/crates/server/src/routes/task_attempts/pr.rs
@@ -307,9 +307,12 @@ pub async fn create_github_pr(
                 tracing::error!("Failed to update workspace PR status: {}", e);
             }
 
-            // Auto-open PR in browser
-            if let Err(e) = utils::browser::open_browser(&pr_info.url).await {
-                tracing::warn!("Failed to open PR in browser: {}", e);
+            // Auto-open PR in browser if config allows it
+            let config = deployment.config().read().await;
+            if config.auto_open_pr_in_browser {
+                if let Err(e) = utils::browser::open_browser(&pr_info.url).await {
+                    tracing::warn!("Failed to open PR in browser: {}", e);
+                }
             }
             deployment
                 .track_if_analytics_allowed(

--- a/crates/services/src/services/config/mod.rs
+++ b/crates/services/src/services/config/mod.rs
@@ -17,15 +17,15 @@ pub enum ConfigError {
     ValidationError(String),
 }
 
-pub type Config = versions::v9::Config;
-pub type NotificationConfig = versions::v9::NotificationConfig;
-pub type EditorConfig = versions::v9::EditorConfig;
-pub type ThemeMode = versions::v9::ThemeMode;
-pub type SoundFile = versions::v9::SoundFile;
-pub type EditorType = versions::v9::EditorType;
-pub type GitHubConfig = versions::v9::GitHubConfig;
-pub type UiLanguage = versions::v9::UiLanguage;
-pub type ShowcaseState = versions::v9::ShowcaseState;
+pub type Config = versions::v10::Config;
+pub type NotificationConfig = versions::v10::NotificationConfig;
+pub type EditorConfig = versions::v10::EditorConfig;
+pub type ThemeMode = versions::v10::ThemeMode;
+pub type SoundFile = versions::v10::SoundFile;
+pub type EditorType = versions::v10::EditorType;
+pub type GitHubConfig = versions::v10::GitHubConfig;
+pub type UiLanguage = versions::v10::UiLanguage;
+pub type ShowcaseState = versions::v10::ShowcaseState;
 
 /// Will always return config, trying old schemas or eventually returning default
 pub async fn load_config_from_file(config_path: &PathBuf) -> Config {

--- a/crates/services/src/services/config/versions/mod.rs
+++ b/crates/services/src/services/config/versions/mod.rs
@@ -7,3 +7,4 @@ pub(super) mod v6;
 pub(super) mod v7;
 pub(super) mod v8;
 pub(super) mod v9;
+pub(super) mod v10;

--- a/crates/services/src/services/config/versions/v10.rs
+++ b/crates/services/src/services/config/versions/v10.rs
@@ -1,0 +1,201 @@
+use anyhow::Error;
+use executors::{executors::BaseCodingAgent, profile::ExecutorProfileId};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+use uuid::Uuid;
+pub use v9::{
+    EditorConfig, EditorType, GitHubConfig, ShowcaseState, SoundFile,
+    ThemeMode, UiLanguage,
+};
+
+use crate::services::config::versions::v9;
+
+fn default_git_branch_prefix() -> String {
+    "vk".to_string()
+}
+
+fn default_pr_auto_description_enabled() -> bool {
+    true
+}
+
+fn default_ntfy_url() -> Option<String> {
+    Some("https://ntfy.sh".to_string())
+}
+
+fn default_ntfy_topic() -> Option<String> {
+    let adjectives = [
+        "happy", "sunny", "clever", "brave", "calm", "eager", "gentle", "lucky", "proud", "swift",
+        "bright", "cool", "fair", "good", "kind", "neat", "nice", "pure", "wise", "warm",
+    ];
+    let nouns = [
+        "panda", "tiger", "eagle", "dolphin", "falcon", "koala", "lion", "owl", "wolf", "zebra",
+        "bear", "cat", "dog", "fox", "hawk", "kite", "lynx", "moth", "seal", "swan",
+    ];
+
+    let uuid = Uuid::new_v4();
+    let bytes = uuid.as_bytes();
+
+    // Use first two bytes for indices
+    let adj_idx = bytes[0] as usize % adjectives.len();
+    let noun_idx = bytes[1] as usize % nouns.len();
+
+    // Use third byte for a small random number suffix to ensure higher uniqueness
+    let suffix = bytes[2] as u16 % 100;
+
+    Some(format!("vibe_kanban_{}_{}_{}", adjectives[adj_idx], nouns[noun_idx], suffix))
+}
+
+fn default_auto_open_pr_in_browser() -> bool {
+    true
+}
+
+fn default_auto_open_app_in_browser() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct NotificationConfig {
+    pub sound_enabled: bool,
+    pub push_enabled: bool,
+    pub sound_file: SoundFile,
+    #[serde(default)]
+    pub ntfy_enabled: bool,
+    #[serde(default = "default_ntfy_url")]
+    pub ntfy_url: Option<String>,
+    #[serde(default = "default_ntfy_topic")]
+    pub ntfy_topic: Option<String>,
+}
+
+impl From<v9::NotificationConfig> for NotificationConfig {
+    fn from(old: v9::NotificationConfig) -> Self {
+        Self {
+            sound_enabled: old.sound_enabled,
+            push_enabled: old.push_enabled,
+            sound_file: old.sound_file,
+            ntfy_enabled: old.ntfy_enabled,
+            ntfy_url: old.ntfy_url.clone(),
+            ntfy_topic: old.ntfy_topic.clone(),
+        }
+    }
+}
+
+impl Default for NotificationConfig {
+    fn default() -> Self {
+        Self {
+            sound_enabled: true,
+            push_enabled: true,
+            sound_file: SoundFile::CowMooing,
+            ntfy_enabled: false,
+            ntfy_url: default_ntfy_url(),
+            ntfy_topic: default_ntfy_topic(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+pub struct Config {
+    pub config_version: String,
+    pub theme: ThemeMode,
+    pub executor_profile: ExecutorProfileId,
+    pub disclaimer_acknowledged: bool,
+    pub onboarding_acknowledged: bool,
+    pub notifications: NotificationConfig,
+    pub editor: EditorConfig,
+    pub github: GitHubConfig,
+    pub analytics_enabled: bool,
+    pub workspace_dir: Option<String>,
+    pub last_app_version: Option<String>,
+    pub show_release_notes: bool,
+    #[serde(default)]
+    pub language: UiLanguage,
+    #[serde(default = "default_git_branch_prefix")]
+    pub git_branch_prefix: String,
+    #[serde(default)]
+    pub showcases: ShowcaseState,
+    #[serde(default = "default_pr_auto_description_enabled")]
+    pub pr_auto_description_enabled: bool,
+    #[serde(default)]
+    pub pr_auto_description_prompt: Option<String>,
+    #[serde(default = "default_auto_open_pr_in_browser")]
+    pub auto_open_pr_in_browser: bool,
+    #[serde(default = "default_auto_open_app_in_browser")]
+    pub auto_open_app_in_browser: bool,
+}
+
+impl Config {
+    fn from_v9_config(old_config: v9::Config) -> Self {
+        Self {
+            config_version: "v10".to_string(),
+            theme: old_config.theme,
+            executor_profile: old_config.executor_profile,
+            disclaimer_acknowledged: old_config.disclaimer_acknowledged,
+            onboarding_acknowledged: old_config.onboarding_acknowledged,
+            notifications: NotificationConfig::from(old_config.notifications),
+            editor: old_config.editor,
+            github: old_config.github,
+            analytics_enabled: old_config.analytics_enabled,
+            workspace_dir: old_config.workspace_dir,
+            last_app_version: old_config.last_app_version,
+            show_release_notes: old_config.show_release_notes,
+            language: old_config.language,
+            git_branch_prefix: old_config.git_branch_prefix,
+            showcases: old_config.showcases,
+            pr_auto_description_enabled: old_config.pr_auto_description_enabled,
+            pr_auto_description_prompt: old_config.pr_auto_description_prompt,
+            auto_open_pr_in_browser: true, // Default to true to maintain existing behavior
+            auto_open_app_in_browser: true, // Default to true to maintain existing behavior
+        }
+    }
+
+    pub fn from_previous_version(raw_config: &str) -> Result<Self, Error> {
+        let old_config = v9::Config::from(raw_config.to_string());
+        Ok(Self::from_v9_config(old_config))
+    }
+}
+
+impl From<String> for Config {
+    fn from(raw_config: String) -> Self {
+        if let Ok(config) = serde_json::from_str::<Config>(&raw_config)
+            && config.config_version == "v10"
+        {
+            return config;
+        }
+
+        match Self::from_previous_version(&raw_config) {
+            Ok(config) => {
+                tracing::info!("Config upgraded to v10");
+                config
+            }
+            Err(e) => {
+                tracing::warn!("Config migration failed: {}, using default", e);
+                Self::default()
+            }
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            config_version: "v10".to_string(),
+            theme: ThemeMode::System,
+            executor_profile: ExecutorProfileId::new(BaseCodingAgent::ClaudeCode),
+            disclaimer_acknowledged: false,
+            onboarding_acknowledged: false,
+            notifications: NotificationConfig::default(),
+            editor: EditorConfig::default(),
+            github: GitHubConfig::default(),
+            analytics_enabled: true,
+            workspace_dir: None,
+            last_app_version: None,
+            show_release_notes: false,
+            language: UiLanguage::default(),
+            git_branch_prefix: default_git_branch_prefix(),
+            showcases: ShowcaseState::default(),
+            pr_auto_description_enabled: true,
+            pr_auto_description_prompt: None,
+            auto_open_pr_in_browser: true,
+            auto_open_app_in_browser: true,
+        }
+    }
+}

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -142,6 +142,10 @@
           "label": "Auto-generate PR description by default",
           "helper": "When enabled, the AI agent will automatically update the PR title and description after creation."
         },
+        "autoOpenInBrowser": {
+          "label": "Auto-open Pull Requests in browser",
+          "helper": "When enabled, pull requests will automatically open in your default browser after creation."
+        },
         "customPrompt": {
           "useCustom": "Use custom prompt",
           "helper": "Custom prompt for the AI agent when generating PR descriptions. Use {pr_number} and {pr_url} as placeholders."
@@ -175,6 +179,10 @@
         "telemetry": {
           "label": "Enable Telemetry",
           "helper": "Enables anonymous usage events tracking to help improve the application. No prompts or project information are collected."
+        },
+        "autoOpenApp": {
+          "label": "Auto-open app in browser on startup",
+          "helper": "When enabled, the Vibe Kanban UI will automatically open in your browser when the application starts."
         }
       },
       "taskTemplates": {

--- a/frontend/src/i18n/locales/zh-Hans/settings.json
+++ b/frontend/src/i18n/locales/zh-Hans/settings.json
@@ -142,6 +142,10 @@
           "label": "默认自动生成PR描述",
           "helper": "启用后，AI代理将在创建PR后自动更新标题和描述。"
         },
+        "autoOpenInBrowser": {
+          "label": "在浏览器中自动打开拉取请求",
+          "helper": "启用后，拉取请求在创建后会自动在默认浏览器中打开。"
+        },
         "customPrompt": {
           "useCustom": "使用自定义提示",
           "helper": "生成PR描述时AI代理使用的自定义提示。使用{pr_number}和{pr_url}作为占位符。"
@@ -168,6 +172,10 @@
         "telemetry": {
           "label": "启用遥测",
           "helper": "启用匿名使用事件跟踪以帮助改进应用程序。不会收集提示或项目信息。"
+        },
+        "autoOpenApp": {
+          "label": "启动时在浏览器中自动打开应用",
+          "helper": "启用后，Vibe Kanban UI 会在应用程序启动时自动在浏览器中打开。"
         }
       },
       "taskTemplates": {

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -507,6 +507,23 @@ export function GeneralSettings() {
           </div>
           <div className="flex items-center space-x-2">
             <Checkbox
+              id="auto-open-pr-in-browser"
+              checked={draft?.auto_open_pr_in_browser ?? true}
+              onCheckedChange={(checked: boolean) =>
+                updateDraft({ auto_open_pr_in_browser: checked })
+              }
+            />
+            <div className="space-y-0.5">
+              <Label htmlFor="auto-open-pr-in-browser" className="cursor-pointer">
+                {t('settings.general.pullRequests.autoOpenInBrowser.label')}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {t('settings.general.pullRequests.autoOpenInBrowser.helper')}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
               id="use-custom-prompt"
               checked={draft?.pr_auto_description_prompt != null}
               onCheckedChange={(checked: boolean) => {
@@ -749,6 +766,23 @@ export function GeneralSettings() {
               </Label>
               <p className="text-sm text-muted-foreground">
                 {t('settings.general.privacy.telemetry.helper')}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="auto-open-app-in-browser"
+              checked={draft?.auto_open_app_in_browser ?? true}
+              onCheckedChange={(checked: boolean) =>
+                updateDraft({ auto_open_app_in_browser: checked })
+              }
+            />
+            <div className="space-y-0.5">
+              <Label htmlFor="auto-open-app-in-browser" className="cursor-pointer">
+                {t('settings.general.privacy.autoOpenApp.label')}
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {t('settings.general.privacy.autoOpenApp.helper')}
               </p>
             </div>
           </div>

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -304,7 +304,7 @@ export type DirectoryEntry = { name: string, path: string, is_directory: boolean
 
 export type DirectoryListResponse = { entries: Array<DirectoryEntry>, current_path: string, };
 
-export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, };
+export type Config = { config_version: string, theme: ThemeMode, executor_profile: ExecutorProfileId, disclaimer_acknowledged: boolean, onboarding_acknowledged: boolean, notifications: NotificationConfig, editor: EditorConfig, github: GitHubConfig, analytics_enabled: boolean, workspace_dir: string | null, last_app_version: string | null, show_release_notes: boolean, language: UiLanguage, git_branch_prefix: string, showcases: ShowcaseState, pr_auto_description_enabled: boolean, pr_auto_description_prompt: string | null, auto_open_pr_in_browser: boolean, auto_open_app_in_browser: boolean, };
 
 export type NotificationConfig = { sound_enabled: boolean, push_enabled: boolean, sound_file: SoundFile, ntfy_enabled: boolean, ntfy_url: string | null, ntfy_topic: string | null, };
 


### PR DESCRIPTION
I run vibe kanban on a server, pull requests are being opened in the browser automatically - investigate where this happens and add a setting in the main configuration to turn this off