### PR TITLE
Fix stale diffs showing after rebase due to cached merge-base (Vibe Kanban)

### DIFF
--- a/frontend/src/hooks/useDiffStream.ts
+++ b/frontend/src/hooks/useDiffStream.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import type { Diff, PatchType } from 'shared/types';
 import { useJsonPatchWsStream } from './useJsonPatchWsStream';
 
@@ -19,19 +20,42 @@ interface UseDiffStreamResult {
   error: string | null;
 }
 
+/** Query key for diff stream refresh - invalidate this to force reconnection */
+export const diffStreamKeys = {
+  refresh: (attemptId: string | null) => ['diffStreamRefresh', attemptId] as const,
+};
+
 export const useDiffStream = (
   attemptId: string | null,
   enabled: boolean,
   options?: UseDiffStreamOptions
 ): UseDiffStreamResult => {
+  // Subscribe to a refresh key that can be invalidated to force WebSocket reconnection
+  // The data value itself doesn't matter - we just need the query to trigger re-renders
+  const { data: refreshNonce } = useQuery({
+    queryKey: diffStreamKeys.refresh(attemptId),
+    queryFn: () => Date.now(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    enabled: !!attemptId,
+  });
+
   const endpoint = (() => {
     if (!attemptId) return undefined;
     const query = `/api/task-attempts/${attemptId}/diff/ws`;
     if (typeof options?.statsOnly === 'boolean') {
       const params = new URLSearchParams();
       params.set('stats_only', String(options.statsOnly));
+      // Include refresh nonce to force new connection when invalidated
+      if (refreshNonce) {
+        params.set('_refresh', String(refreshNonce));
+      }
       return `${query}?${params.toString()}`;
     } else {
+      // Include refresh nonce to force new connection when invalidated
+      if (refreshNonce) {
+        return `${query}?_refresh=${refreshNonce}`;
+      }
       return query;
     }
   })();

--- a/frontend/src/hooks/useRebase.ts
+++ b/frontend/src/hooks/useRebase.ts
@@ -3,6 +3,7 @@ import { attemptsApi, Result } from '@/lib/api';
 import type { RebaseTaskAttemptRequest } from 'shared/types';
 import type { GitOperationError } from 'shared/types';
 import { repoBranchKeys } from './useRepoBranches';
+import { diffStreamKeys } from './useDiffStream';
 
 export function useRebase(
   attemptId: string | undefined,
@@ -54,6 +55,13 @@ export function useRebase(
             queryKey: repoBranchKeys.byRepo(repoId),
           });
         }
+
+        // Force diff stream to reconnect with fresh base_commit after rebase
+        // This fixes the issue where already-merged commits temporarily appear
+        // because the old WebSocket was using a stale merge-base
+        queryClient.invalidateQueries({
+          queryKey: diffStreamKeys.refresh(attemptId ?? null),
+        });
 
         onSuccess?.();
       },


### PR DESCRIPTION
## Summary

This PR fixes an issue where the diff view temporarily shows already-merged commits after rebasing a task branch.

## Problem

When viewing a task's diffs and then performing a rebase:
1. The diff stream's `base_commit` (merge-base) was calculated once when the WebSocket connection started
2. After rebase, the git merge-base changes, but the running WebSocket stream continued using the stale `base_commit`
3. This caused diffs to incorrectly show commits that were already merged into the target branch
4. Refreshing the page or navigating away and back would fix it (by establishing a new connection with fresh merge-base)

## Solution

Added a mechanism to force the diff stream WebSocket to reconnect after a successful rebase operation:

### Changes to `useDiffStream.ts`
- Added `diffStreamKeys.refresh()` query key that can be invalidated to trigger reconnection
- Added a `useQuery` hook that subscribes to this refresh key and generates a nonce
- The nonce is appended to the WebSocket URL as a `_refresh` parameter
- When the refresh key is invalidated, the nonce changes, causing the endpoint URL to change
- `useJsonPatchWsStream` detects the endpoint change and closes/reopens the connection

### Changes to `useRebase.ts`
- Imported `diffStreamKeys` from `useDiffStream`
- Added invalidation of `diffStreamKeys.refresh(attemptId)` in the `onSuccess` callback
- This triggers the diff stream to reconnect with a fresh `base_commit` after rebase completes

## How it works

1. User completes a rebase operation
2. `useRebase.onSuccess` fires and invalidates the `diffStreamRefresh` query
3. `useDiffStream` re-runs its query, getting a new `refreshNonce` (timestamp)
4. The WebSocket endpoint URL changes (includes the new nonce)
5. `useJsonPatchWsStream` detects the endpoint change and reconnects
6. Backend handles the new connection by calculating a fresh `base_commit` via `get_base_commit()`
7. Fresh diffs are streamed, showing only the actual changes on the rebased branch

---

This PR was written using [Vibe Kanban](https://vibekanban.com)