### PR TITLE
Add project import and export functionality (Vibe Kanban)

### DIFF
--- a/crates/db/src/models/project.rs
+++ b/crates/db/src/models/project.rs
@@ -38,6 +38,26 @@ pub struct CreateProject {
     pub repositories: Vec<CreateProjectRepo>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ProjectRepoExport {
+    pub display_name: String,
+    pub git_repo_path: String,
+    pub setup_script: Option<String>,
+    pub cleanup_script: Option<String>,
+    pub copy_files: Option<String>,
+    pub parallel_setup_script: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+pub struct ProjectExport {
+    pub name: String,
+    pub dev_script: Option<String>,
+    pub dev_script_working_dir: Option<String>,
+    pub default_agent_working_dir: Option<String>,
+    pub prefer_remote_branch: bool,
+    pub repositories: Vec<ProjectRepoExport>,
+}
+
 #[derive(Debug, Deserialize, TS)]
 pub struct UpdateProject {
     pub name: Option<String>,

--- a/crates/server/src/routes/projects.rs
+++ b/crates/server/src/routes/projects.rs
@@ -13,7 +13,7 @@ use axum::{
     routing::{get, post},
 };
 use db::models::{
-    project::{CreateProject, Project, ProjectError, SearchResult, UpdateProject},
+    project::{CreateProject, Project, ProjectError, ProjectExport, SearchResult, UpdateProject},
     project_repo::{CreateProjectRepo, ProjectRepo, UpdateProjectRepo},
     repo::Repo,
 };
@@ -42,6 +42,39 @@ pub struct LinkToExistingRequest {
 pub struct CreateRemoteProjectRequest {
     pub organization_id: Uuid,
     pub name: String,
+}
+
+pub async fn export_all_projects_handler(
+    State(deployment): State<DeploymentImpl>,
+) -> Result<ResponseJson<ApiResponse<Vec<ProjectExport>>>, ApiError> {
+    let exports = deployment
+        .project()
+        .export_all_projects(&deployment.db().pool)
+        .await?;
+    Ok(ResponseJson(ApiResponse::success(exports)))
+}
+
+pub async fn export_project_handler(
+    State(deployment): State<DeploymentImpl>,
+    Extension(project): Extension<Project>,
+) -> Result<ResponseJson<ApiResponse<ProjectExport>>, ApiError> {
+    let export = deployment
+        .project()
+        .export_project(&deployment.db().pool, project.id)
+        .await?;
+    Ok(ResponseJson(ApiResponse::success(export)))
+}
+
+pub async fn import_projects_handler(
+    State(deployment): State<DeploymentImpl>,
+    Json(payload): Json<Vec<ProjectExport>>,
+) -> Result<ResponseJson<ApiResponse<Vec<Project>>>, ApiError> {
+    let projects = deployment
+        .project()
+        .import_projects(&deployment.db().pool, deployment.repo(), payload)
+        .await?;
+
+    Ok(ResponseJson(ApiResponse::success(projects)))
 }
 
 pub async fn get_projects(
@@ -588,6 +621,7 @@ pub fn router(deployment: &DeploymentImpl) -> Router<DeploymentImpl> {
             "/",
             get(get_project).put(update_project).delete(delete_project),
         )
+        .route("/export", get(export_project_handler))
         .route("/remote/members", get(get_project_remote_members))
         .route("/search", get(search_project_files))
         .route("/open-editor", post(open_project_in_editor))
@@ -607,6 +641,8 @@ pub fn router(deployment: &DeploymentImpl) -> Router<DeploymentImpl> {
 
     let projects_router = Router::new()
         .route("/", get(get_projects).post(create_project))
+        .route("/export", get(export_all_projects_handler))
+        .route("/import", post(import_projects_handler))
         .route(
             "/{project_id}/repositories/{repo_id}",
             get(get_project_repository)

--- a/frontend/src/components/projects/ProjectDetail.tsx
+++ b/frontend/src/components/projects/ProjectDetail.tsx
@@ -22,6 +22,7 @@ import {
   Edit,
   Loader2,
   Trash2,
+  Download,
 } from 'lucide-react';
 
 interface ProjectDetailProps {
@@ -59,6 +60,26 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
 
   const handleEditClick = () => {
     navigate(`/settings/projects?projectId=${projectId}`);
+  };
+
+  const handleExport = async () => {
+    if (!project) return;
+    try {
+      const data = await projectsApi.export(projectId);
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${project.name.toLowerCase().replace(/\s+/g, '-')}-export-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+       console.error('Failed to export project', error);
+    }
   };
 
   if (isLoading) {
@@ -117,6 +138,10 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
           <Button onClick={() => navigate(`/projects/${projectId}/tasks`)}>
             <CheckSquare className="mr-2 h-4 w-4" />
             View Tasks
+          </Button>
+          <Button variant="outline" onClick={handleExport}>
+            <Download className="mr-2 h-4 w-4" />
+            Export
           </Button>
           <Button variant="outline" onClick={handleEditClick}>
             <Edit className="mr-2 h-4 w-4" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import {
   ExecutionProcessRepoState,
   GitBranch,
   Project,
+  ProjectExport,
   ProjectRepo,
   Repo,
   RepoWithTargetBranch,
@@ -250,6 +251,24 @@ export const projectsApi = {
       body: JSON.stringify(data),
     });
     return handleApiResponse<Project>(response);
+  },
+
+  export: async (id: string): Promise<ProjectExport> => {
+    const response = await makeRequest(`/api/projects/${id}/export`);
+    return handleApiResponse<ProjectExport>(response);
+  },
+
+  exportAll: async (): Promise<ProjectExport[]> => {
+    const response = await makeRequest(`/api/projects/export`);
+    return handleApiResponse<ProjectExport[]>(response);
+  },
+
+  import: async (data: ProjectExport[]): Promise<Project[]> => {
+    const response = await makeRequest(`/api/projects/import`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    return handleApiResponse<Project[]>(response);
   },
 
   getRemoteMembers: async (

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6,6 +6,10 @@
 
 export type SharedTaskResponse = { task: SharedTask, user: UserData | null, };
 
+export type ProjectRepoExport = { display_name: string, git_repo_path: string, setup_script: string | null, cleanup_script: string | null, copy_files: string | null, parallel_setup_script: boolean, };
+
+export type ProjectExport = { name: string, dev_script: string | null, dev_script_working_dir: string | null, default_agent_working_dir: string | null, prefer_remote_branch: boolean, repositories: Array<ProjectRepoExport>, };
+
 export type AssigneesQuery = { project_id: string, };
 
 export type SharedTask = { id: string, organization_id: string, project_id: string, creator_user_id: string | null, assignee_user_id: string | null, deleted_by_user_id: string | null, title: string, description: string | null, status: TaskStatus, deleted_at: string | null, shared_at: string | null, created_at: string, updated_at: string, };


### PR DESCRIPTION
This PR introduces the ability to import and export projects, including their settings and associated repository configurations (like scripts).

**Changes:**
- **Backend Models:** Introduced `ProjectExport` and `ProjectRepoExport` structures to serialize project data.
- **Service Layer:** Implemented core logic for exporting and importing projects in `ProjectService`. This handles fetching project details, repository paths, and scripts, as well as creating/updating projects during import.
- **API Endpoints:** Added new routes:
    - `GET /api/projects/export`: Exports all projects as a JSON array.
    - `GET /api/projects/{id}/export`: Exports a specific project.
    - `POST /api/projects/import`: Imports projects from a JSON payload.
- **Frontend:**
    - Added "Export All" and "Import" buttons to the main Projects list view.
    - Added an "Export" button to the individual Project details view.
    - Integrated with the new API endpoints to handle file generation (for export) and parsing (for import).

**Why:**
This feature allows users to back up their project configurations or transfer them between different instances of Vibe Kanban (assuming repository paths are valid on the target machine). It simplifies the management of complex project setups involving multiple repositories and custom scripts.

This PR was written using [Vibe Kanban](https://vibekanban.com)